### PR TITLE
Add Python 3.13 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
## Summary
- add Python 3.13 to the CI test matrix
- leave existing 3.10, 3.11, and 3.12 coverage unchanged

## Notes
- Issue #7 asks for 3.11 and 3.13; 3.11 is already present on main, so this PR adds the remaining 3.13 entry.

## Testing
- git diff --check

Closes #7