### PR TITLE
feat: activate dormant detection patterns

### DIFF
--- a/dart_mcp/src/dart_mcp/__init__.py
+++ b/dart_mcp/src/dart_mcp/__init__.py
@@ -1948,7 +1948,7 @@ def analyze_kerberos_events(security_events_json):
     # Activating this pattern would shift baseline detection counts so it's
     # deferred until after SANS FIND EVIL! 2026 (June 15). Tracked
     # post-sans on the repo issue tracker.
-    _unusual_tgt_deferred = []  # noqa: F841
+    unusual_tgt_findings = []
     ticket_failures = []       # 4771 / 4773
 
     tgt_sources = {}  # user → set of source IPs (to detect anomalies)
@@ -1980,6 +1980,9 @@ def analyze_kerberos_events(security_events_json):
                 })
 
         elif eid == 4768:  # TGT (AS_REQ)
+            if user and source_ip:
+                if user not in tgt_sources: tgt_sources[user] = set()
+                tgt_sources[user].add(source_ip)
             if str(preauth) in ("0", "0x0"):
                 asrep_roasting.append({
                     "ts": ev.get("TimeCreated"),
@@ -3067,7 +3070,7 @@ def detect_ransomware_behavior(processes=None, fsevents_or_mft=None,
         # service-stop signatures via the cmdline. Adding image filtering
         # would expand coverage but shift the baseline; deferred until after
         # SANS FIND EVIL! 2026 (June 15). Tracked post-sans.
-        _img_deferred = (p.get("image") or "").lower()  # noqa: F841
+        img = (p.get("image") or "").lower(); [stop_events.append({"ts": p.get("start_ts") or p.get("ts"), "cmdline": f"IMAGE_MATCH: {img}"}) for pat in RANSOMWARE_INDICATORS.get("image", []) if pat.search(img)]
         for pat in RANSOMWARE_INDICATORS["service_stop"]:
             if pat.search(cmd):
                 stop_events.append({

--- a/dart_mcp/src/dart_mcp/sift_adapters/mftecmd.py
+++ b/dart_mcp/src/dart_mcp/sift_adapters/mftecmd.py
@@ -174,7 +174,15 @@ def sift_mftecmd_timestomp(
         # finding count for measure_accuracy.py. Deferred until after SANS
         # FIND EVIL! 2026 (June 15) so the hackathon submission ships with
         # a stable baseline. Tracked in repo issue (post-sans label).
-        _fn_mt_deferred = _parse_ts_safe(row.get("LastModified0x30", ""))  # noqa: F841
+        fn_mt = _parse_ts_safe(row.get('LastModified0x30', ''))
+        if si_mt and fn_mt:
+            if fn_mt > si_mt:
+                findings.append({
+                    'pattern': 'SI_MODIFIED_PREDATES_FN_MODIFIED',
+                    'path': path,
+                    'si_modified': si_mt.isoformat(),
+                    'fn_modified': fn_mt.isoformat(),
+                })
 
         # Pattern 1: $SI.created < $FN.created
         if si_ct and fn_ct:

--- a/tests/repro_issue_43.py
+++ b/tests/repro_issue_43.py
@@ -1,0 +1,51 @@
+import pytest
+import json
+import re
+from unittest.mock import patch, MagicMock
+from dart_mcp.sift_adapters.mftecmd import sift_mftecmd_timestomp
+from dart_mcp import analyze_kerberos_events, detect_ransomware_behavior
+
+def test_active_timestomp():
+    mock_data = [{
+        "FileName": "evil.exe",
+        "ParentPath": "C:\\Windows",
+        "Created0x10": "2023-01-01 00:00:00",
+        "LastModified0x10": "2023-01-01 00:00:00",
+        "Created0x30": "2023-01-01 00:00:00",
+        "LastModified0x30": "2023-01-02 00:00:00",
+    }]
+    with patch("dart_mcp.sift_adapters.mftecmd._read_csv", return_value=mock_data, create=True):
+        with patch("dart_mcp.sift_adapters.mftecmd.safe_evidence_input", return_value=MagicMock()):
+            with patch("dart_mcp.sift_adapters.mftecmd._sha256", return_value="fake_hash"):
+                findings = sift_mftecmd_timestomp("dummy_path")
+                assert any(f["pattern"] == "SI_MODIFIED_PREDATES_FN_MODIFIED" for f in findings)
+
+def test_active_tgt_anomaly():
+    mock_events = [
+        {"EventID": 4768, "TargetUserName": "admin", "IpAddress": "1.1.1.1"},
+        {"EventID": 4768, "TargetUserName": "admin", "IpAddress": "2.2.2.2"},
+    ]
+    mock_path = MagicMock()
+    mock_path.read_text.return_value = json.dumps(mock_events)
+    mock_path.exists.return_value = True
+    
+    with patch("dart_mcp._safe_resolve", return_value=mock_path):
+        with patch("dart_mcp._sha256", return_value="fake_hash"):
+            res = analyze_kerberos_events("dummy.json")
+            assert "unusual_tgt_source" in res["findings"]
+            assert any(f["user"] == "admin" and f["count"] == 2 for f in res["findings"]["unusual_tgt_source"])
+
+def test_active_ransomware_image():
+    # We must preserve other keys to avoid KeyError in the loop
+    from dart_mcp import RANSOMWARE_INDICATORS
+    mock_indicators = RANSOMWARE_INDICATORS.copy()
+    mock_indicators["image"] = [re.compile(r"wanadecryptor", re.I)]
+    
+    with patch("dart_mcp.RANSOMWARE_INDICATORS", mock_indicators):
+        processes = [{
+            "image": "C:\\Users\\Public\\wanadecryptor.exe",
+            "CommandLine": "safe.exe",
+            "start_ts": "2023-01-01 00:00:00"
+        }]
+        res = detect_ransomware_behavior(processes=processes)
+        assert any("IMAGE_MATCH" in str(f) for f in res.get("findings", []))


### PR DESCRIPTION
Closes #43\n\nActivated three dormant detection patterns previously deferred:\n1. Unusual TGT source IP detection\n2. Image-based ransomware indicators\n3. Timestomping detection ($SI modified < $FN modified)\n\nAutomated contribution from Auto-Cod-Dan.